### PR TITLE
Change units to rem

### DIFF
--- a/build/css/tempusdominus-bootstrap-4.css
+++ b/build/css/tempusdominus-bootstrap-4.css
@@ -20,7 +20,7 @@
     display: block;
     margin: 2px 0;
     padding: 4px;
-    width: 12.8vw; }
+    width: 12.8rem; }
     @media (min-width: 576px) {
       .bootstrap-datetimepicker-widget.dropdown-menu.timepicker-sbs {
         width: 38em; } }


### PR DESCRIPTION
Bootstrap Beta 2 (and maybe earlier too) uses relative ems (rem) units instead of viewport percentage (vw), this fixes the table width. This should be a font thing, not a viewport thing. Fixes #18 