### PR TITLE
hide the picker on close action

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -820,6 +820,9 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                 case 'clear':
                     this.clear();
                     break;
+                case 'close':
+                    this.hide();
+                    break;
                 case 'today':
                     {
                         const todaysDate = this.getMoment();


### PR DESCRIPTION
When showClose is true, it uses data-action 'close', but 'close' was not handled.