### PR TITLE
set href and tabindex on show buttons

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -152,24 +152,32 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
             const row = [];
             if (this._options.buttons.showToday) {
                 row.push($('<td>').append($('<a>').attr({
+                    href: '#',
+                    tabindex: '-1',
                     'data-action': 'today',
                     'title': this._options.tooltips.today
                 }).append($('<span>').addClass(this._options.icons.today))));
             }
             if (!this._options.sideBySide && this._hasDate() && this._hasTime()) {
                 row.push($('<td>').append($('<a>').attr({
+                    href: '#',
+                    tabindex: '-1',
                     'data-action': 'togglePicker',
                     'title': this._options.tooltips.selectTime
                 }).append($('<span>').addClass(this._options.icons.time))));
             }
             if (this._options.buttons.showClear) {
                 row.push($('<td>').append($('<a>').attr({
+                    href: '#',
+                    tabindex: '-1',
                     'data-action': 'clear',
                     'title': this._options.tooltips.clear
                 }).append($('<span>').addClass(this._options.icons.clear))));
             }
             if (this._options.buttons.showClose) {
                 row.push($('<td>').append($('<a>').attr({
+                    href: '#',
+                    tabindex: '-1',
                     'data-action': 'close',
                     'title': this._options.tooltips.close
                 }).append($('<span>').addClass(this._options.icons.close))));


### PR DESCRIPTION
bootstrap 4 doesn't style the close icon properly unless href or tabindex is set.