### PR TITLE
Target data-toggle instead of .input-group-append class.

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -35,10 +35,9 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
 
         _init() {
             if (this._element.hasClass('input-group')) {
-                // in case there is more then one 'input-group-addon' Issue #48
                 const datepickerButton = this._element.find('.datepickerbutton');
                 if (datepickerButton.length === 0) {
-                    this.component = this._element.find('.input-group-append');
+                    this.component = this._element.find('[data-toggle="datetimepicker"]');
                 } else {
                     this.component = datepickerButton;
                 }


### PR DESCRIPTION
A field that uses `input-group-prepend` will only work once and throw errors to console ([fiddle](https://jsfiddle.net/cethb3La/1/)). Targeting *both* fields works but isn't ideal because it will only work for the first `input-group-*` field it finds and it's possible to have both in one field. This PR instead targets the expected `data-toggle` value.