### PR TITLE
Respect keepOpen option even with time precision.

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -805,16 +805,31 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                             }
                         }
                         this._setValue(lastPicked.clone().hours(hour), this._getLastPickedDateIndex());
-                        this._doAction(e, 'showPicker');
+                        if (!this._isEnabled('m') && !this._options.keepOpen && !this._options.inline) {
+                            this.hide();
+                        }
+                        else {
+                            this._doAction(e, 'showPicker');
+                        }
                         break;
                     }
                 case 'selectMinute':
                     this._setValue(lastPicked.clone().minutes(parseInt($(e.target).text(), 10)), this._getLastPickedDateIndex());
-                    this._doAction(e, 'showPicker');
+                    if (!this._isEnabled('s') && !this._options.keepOpen && !this._options.inline) {
+                        this.hide();
+                    }
+                    else {
+                        this._doAction(e, 'showPicker');
+                    }
                     break;
                 case 'selectSecond':
                     this._setValue(lastPicked.clone().seconds(parseInt($(e.target).text(), 10)), this._getLastPickedDateIndex());
-                    this._doAction(e, 'showPicker');
+                    if (!this._options.keepOpen && !this._options.inline) {
+                        this.hide();
+                    }
+                    else {
+                        this._doAction(e, 'showPicker');
+                    }
                     break;
                 case 'clear':
                     this.clear();


### PR DESCRIPTION
Currently, the `keepOpen` option only has an effect when there is no time precision. This PR will respect the `keepOpen` option even with time precision by:

- Hiding the picker after an hour is selected if `_isEnabled('m')` returns false.
- Hiding the picker after a minute is selected if `_isEnabled('s')` returns false.
- Hiding the picker after a second is selected.

*Assuming `keepOpen` and `inline` are both false, in all cases.*

For example, a `format` setting of `YYYY-MM-DD HH` will close the picker after an hour is selected, `YYYY-MM-DD HH:mm` will close after a minute is selected, and `YYYY-MM-DD HH:mm:ss` will close the picker after a second is selected.

Let me know if you'd like a fiddle showing this in action.