### PR TITLE
Update Bootstrap version and reduce popper.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "url": "https://github.com/tempusdominus/bootstrap-4/issues"
   },
   "dependencies": {
-    "bootstrap": "4.0.0-beta.3",
+    "bootstrap": "4.0.0",
     "jquery": "^1.9.1 || ^2.0 || ^3.0",
-    "popper.js": "1.13.0",
+    "popper.js": "^1.12.9",
     "moment": "^2.17",
     "moment-timezone": "^0.5.11"
   },

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "moment-timezone": "^0.5.11"
   },
   "peerDependencies": {
-    "bootstrap": "4.0.0-beta.3",
+    "bootstrap": "4.0.0",
     "jquery": "^1.9.1 || ^2.0 || ^3.0",
-    "popper.js": "1.13.0",
+    "popper.js": "^1.12.9",
     "moment": "^2.17",
     "moment-timezone": "^0.5.11",
     "tempusdominus-core": "5.0.0-alpha12"


### PR DESCRIPTION
Bootstrap 4.0.0 is released.
Bootstrap 4.0.0 requires popper.js 1.12.9. The used version 1.13.0 is still a next-version.