### PR TITLE
Do not close picker on selection if AM/PM is enabled in time format.

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -813,7 +813,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                             }
                         }
                         this._setValue(lastPicked.clone().hours(hour), this._getLastPickedDateIndex());
-                        if (!this._isEnabled('m') && !this._options.keepOpen && !this._options.inline) {
+                        if (!this._isEnabled('a') && !this._isEnabled('m') && !this._options.keepOpen && !this._options.inline) {
                             this.hide();
                         }
                         else {
@@ -823,7 +823,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     }
                 case 'selectMinute':
                     this._setValue(lastPicked.clone().minutes(parseInt($(e.target).text(), 10)), this._getLastPickedDateIndex());
-                    if (!this._isEnabled('s') && !this._options.keepOpen && !this._options.inline) {
+                    if (!this._isEnabled('a') && !this._isEnabled('s') && !this._options.keepOpen && !this._options.inline) {
                         this.hide();
                     }
                     else {
@@ -832,7 +832,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     break;
                 case 'selectSecond':
                     this._setValue(lastPicked.clone().seconds(parseInt($(e.target).text(), 10)), this._getLastPickedDateIndex());
-                    if (!this._options.keepOpen && !this._options.inline) {
+                    if (!this._isEnabled('a') && !this._options.keepOpen && !this._options.inline) {
                         this.hide();
                     }
                     else {


### PR DESCRIPTION
This fixes #72 by preventing closing the picker if AM/PM (a/A) is enabled in the time format.

This change does not handle closing the picker at all if AM/PM is enabled because, unlike the other pickers, AM/PM is a toggle so there is no `selectXXX` event to use to trigger a close.

When AM/PM is not enabled, the typical behavior added in #53 will continue.

This change relies on tempusdominus/core#5.