### PR TITLE
Update events namespaces on docs

### DIFF
--- a/docs/Events/index.html
+++ b/docs/Events/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -124,45 +124,20 @@
             <div class="col-12 col-md-3 col-xl-2 bd-sidebar"><nav class="bd-links" id="docsNavbarContent">
     <div class="bd-toc-item active">
         <ul class="nav bd-sidenav">
-            <li class="active bd-sidenav-active"><a href="#events">Events</a></li>
-            <li><a href="#hidedatetimepicker">hide.datetimepicker</a></li>
-            <li><a href="#showdatetimepicker">show.datetimepicker</a></li>
+            <li class="active bd-sidenav-active"><a href="#events">Events</a></li>            
             <li><a href="#changedatetimepicker">change.datetimepicker</a></li>
-            <li><a href="#errordatetimepicker">error.datetimepicker</a></li>
-            <li><a href="#updatedatetimepicker">update.datetimepicker</a></li>
+            <li><a href="#hidedatetimepicker">datetimepicker.hide</a></li>
+            <li><a href="#showdatetimepicker">datetimepicker.show</a></li>
+            <li><a href="#errordatetimepicker">datetimepicker.error</a></li>
+            <li><a href="#updatedatetimepicker">datetimepicker.update</a></li>
         </ul>
     </div>
 </nav></div>
             <div class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5 bd-content" role="main">
                 <h1 class="bd-title">Events</h1>
                 
-                
+               
 <h2 id="events">Events</h2>
-<h3 id="hidedatetimepicker">hide.datetimepicker</h3>
-<p>Fired when the widget is hidden.</p>
-<p>Parameters:</p>
-<pre><code>e = {
-    date //the currently set date. Type: moment object (clone)
-}
-</code></pre>
-
-<p>Emitted from:</p>
-<ul>
-<li>toggle()</li>
-<li>hide()</li>
-<li>disable()</li>
-</ul>
-<hr />
-<h3 id="showdatetimepicker">show.datetimepicker</h3>
-<p>Fired when the widget is shown.</p>
-<p>Parameters:</p>
-<p>No parameters are include, listen to <code>change.datetimepicker</code> instead</p>
-<p>Emitted from:</p>
-<ul>
-<li>toggle()</li>
-<li>show()</li>
-</ul>
-<hr />
 <h3 id="changedatetimepicker">change.datetimepicker</h3>
 <p>Fired when the date is changed, including when changed to a non-date (e.g. When keepInvalid=true).</p>
 <p>Parameters:</p>
@@ -182,7 +157,32 @@
 <li>daysOfWeekDisabled()</li>
 </ul>
 <hr />
-<h3 id="errordatetimepicker">error.datetimepicker</h3>
+<h3 id="hidedatetimepicker">datetimepicker.hide</h3>
+<p>Fired when the widget is hidden.</p>
+<p>Parameters:</p>
+<pre><code>e = {
+    date //the currently set date. Type: moment object (clone)
+}
+</code></pre>
+
+<p>Emitted from:</p>
+<ul>
+<li>toggle()</li>
+<li>hide()</li>
+<li>disable()</li>
+</ul>
+<hr />
+<h3 id="showdatetimepicker">datetimepicker.show</h3>
+<p>Fired when the widget is shown.</p>
+<p>Parameters:</p>
+<p>No parameters are include, listen to <code>change.datetimepicker</code> instead</p>
+<p>Emitted from:</p>
+<ul>
+<li>toggle()</li>
+<li>show()</li>
+</ul>
+<hr />
+<h3 id="errordatetimepicker">datetimepicker.error</h3>
 <p>Fired when a selected date fails to pass validation.</p>
 <p>Parameters:</p>
 <pre><code>e = {
@@ -199,7 +199,7 @@
 <li>setValue() <em>private function</em></li>
 </ul>
 <hr />
-<h3 id="updatedatetimepicker">update.datetimepicker</h3>
+<h3 id="updatedatetimepicker">datetimepicker.update</h3>
 <p>Fired (in most cases) when the <code>viewDate</code> changes. E.g. Next and Previous buttons, selecting a year.</p>
 <p>Parameters:</p>
 <pre><code>e = {


### PR DESCRIPTION
Update events namespaces, on docs, according to source code.
close #74, close #65, close #40

The namespaces on the source code is being show as:
`EMIT_EVENT_KEY + 'event',`
But on docs is show as using
`'event' + EVENT_KEY`