### PR TITLE
Add Django package to the docs for Tempus Dominus

### DIFF
--- a/src/docs/Installing.md
+++ b/src/docs/Installing.md
@@ -11,7 +11,8 @@
 # Installation Guides
 * [CDN](#cdn)
 * [Nuget](#nuget)
-* [Rails](#rails-)
+* [Rails](#rails)
+* [Django](#django)
 * [Angular](#angular-wrapper)
 * [Meteor.js](#meteorjs)
 * [Manual](#manual)
@@ -49,6 +50,14 @@ Rails 5.1 Support - [Bootstrap 4 Datetime Picker Rails](https://github.com/Bialo
 2. Execute `bundle`
 3. Add `//= require tempusdominus-bootstrap-4.js` to your `application.js`
 4. Add `@import "tempusdominus-bootstrap-4.css"` to your `application.scss`
+
+### Django
+
+Python package for Django: [Django Tempus Dominus](https://pypi.org/project/django-tempus-dominus/)
+
+1. Install via pip: `pip install django-tempus-dominus`
+2. Widgets are provided for Date, DateTime, and Time.
+3. See the link above for full examples with Django Forms, Widgets, and Templates.
 
 ### Angular Wrapper
 Need new wrapper for this version.

--- a/src/docs/Installing.md
+++ b/src/docs/Installing.md
@@ -57,7 +57,7 @@ Python package for Django: [Django Tempus Dominus](https://pypi.org/project/djan
 
 1. Install via pip: `pip install django-tempus-dominus`
 2. Widgets are provided for Date, DateTime, and Time.
-3. See the link above for full examples with Django Forms, Widgets, and Templates.
+3. [Full examples are available with Django Forms, Widgets, and Templates](https://pypi.org/project/django-tempus-dominus/).
 
 ### Angular Wrapper
 Need new wrapper for this version.


### PR DESCRIPTION
Just a note: I actually read contributing guidelines, and there's no development branch to target. So I'm targeting master and hoping it doesn't get closed.

Most of all: thanks for your efforts, this is an awesome library. I've built a Python package which includes widgets for Django. This links to the package on PyPI from the documentation... and fixes the anchor tag in the docs for Rails.