### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "files": [
     "build",
     "src/js/**/*.js",
-    "src/scss/**/*.scss",
+    "src/sass/**/*.scss",
     "Gruntfile.js"
   ]
 }


### PR DESCRIPTION
The typo was merged with #142, the `scss` directory does not exist, the `sass` directory does.