### PR TITLE
Fix for _setValue with null date

### DIFF
--- a/build/js/tempusdominus-bootstrap-4.js
+++ b/build/js/tempusdominus-bootstrap-4.js
@@ -410,6 +410,8 @@ var DateTimePicker = function ($, moment) {
                 if (!this._options.allowMultidate || this._dates.length === 1) {
                     this.unset = true;
                     this._dates = [];
+                    this._dates[0] = this.getMoment();
+                    this._viewDate = this.getMoment().clone();
                     this._datesFormatted = [];
                 } else {
                     outpValue = this._element.data('date') + ',';


### PR DESCRIPTION
During our development we found problems with the picker when you manually removed the selected date by clearing the date from the text box. After doing this we found that the drop down would not display. 

We found tried the #185 solution and found that it would create another issue with the rendering of the view after multiple clicks in and out of the text box. This caused us to look deeper into the code and we found that the root cause was that when the _setValue was called with a null it was not restoring the _dates array to ensure that it always had a value as position 0.

As with #185 I could not find the code in the **src** just and have therefore modified the **build**.
