### PR TITLE
Fix use of Font Awesome 5 with JS/SVG engine

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -44,8 +44,12 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
             }
         }
 
+        _spanIcon(icon) {
+            return $('<span>').append($('<i>').addClass(icon));
+        };
+        
         _getDatePickerTemplate() {
-            const headTemplate = $('<thead>').append($('<tr>').append($('<th>').addClass('prev').attr('data-action', 'previous').append($('<span>').addClass(this._options.icons.previous))).append($('<th>').addClass('picker-switch').attr('data-action', 'pickerSwitch').attr('colspan', `${this._options.calendarWeeks ? '6' : '5'}`)).append($('<th>').addClass('next').attr('data-action', 'next').append($('<span>').addClass(this._options.icons.next)))),
+            const headTemplate = $('<thead>').append($('<tr>').append($('<th>').addClass('prev').attr('data-action', 'previous').append(this._spanIcon(this._options.icons.previous))).append($('<th>').addClass('picker-switch').attr('data-action', 'pickerSwitch').attr('colspan', `${this._options.calendarWeeks ? '6' : '5'}`)).append($('<th>').addClass('next').attr('data-action', 'next').append(this._spanIcon(this._options.icons.next)))),
                 contTemplate = $('<tbody>').append($('<tr>').append($('<td>').attr('colspan', `${this._options.calendarWeeks ? '8' : '7'}`)));
 
             return [$('<div>').addClass('datepicker-days').append($('<table>').addClass('table table-sm').append(headTemplate).append($('<tbody>'))), $('<div>').addClass('datepicker-months').append($('<table>').addClass('table-condensed').append(headTemplate.clone()).append(contTemplate.clone())), $('<div>').addClass('datepicker-years').append($('<table>').addClass('table-condensed').append(headTemplate.clone()).append(contTemplate.clone())), $('<div>').addClass('datepicker-decades').append($('<table>').addClass('table-condensed').append(headTemplate.clone()).append(contTemplate.clone()))];
@@ -61,8 +65,8 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     href: '#',
                     tabindex: '-1',
                     'title': this._options.tooltips.incrementHour
-                }).addClass('btn').attr('data-action', 'incrementHours').append($('<span>').addClass(this._options.icons.up))));
-                middleRow.append($('<td>').append($('<span>').addClass('timepicker-hour').attr({
+                }).addClass('btn').attr('data-action', 'incrementHours').append(this._spanIcon(this._options.icons.up))));
+                middleRow.append($('<td>').append(this._spanIcon('timepicker-hour').attr({
                     'data-time-component': 'hours',
                     'title': this._options.tooltips.pickHour
                 }).attr('data-action', 'showHours')));
@@ -70,7 +74,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     href: '#',
                     tabindex: '-1',
                     'title': this._options.tooltips.decrementHour
-                }).addClass('btn').attr('data-action', 'decrementHours').append($('<span>').addClass(this._options.icons.down))));
+                }).addClass('btn').attr('data-action', 'decrementHours').append(this._spanIcon(this._options.icons.down))));
             }
             if (this._isEnabled('m')) {
                 if (this._isEnabled('h')) {
@@ -82,8 +86,8 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     href: '#',
                     tabindex: '-1',
                     'title': this._options.tooltips.incrementMinute
-                }).addClass('btn').attr('data-action', 'incrementMinutes').append($('<span>').addClass(this._options.icons.up))));
-                middleRow.append($('<td>').append($('<span>').addClass('timepicker-minute').attr({
+                }).addClass('btn').attr('data-action', 'incrementMinutes').append(this._spanIcon(this._options.icons.up))));
+                middleRow.append($('<td>').append(this._spanIcon('timepicker-minute').attr({
                     'data-time-component': 'minutes',
                     'title': this._options.tooltips.pickMinute
                 }).attr('data-action', 'showMinutes')));
@@ -91,7 +95,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     href: '#',
                     tabindex: '-1',
                     'title': this._options.tooltips.decrementMinute
-                }).addClass('btn').attr('data-action', 'decrementMinutes').append($('<span>').addClass(this._options.icons.down))));
+                }).addClass('btn').attr('data-action', 'decrementMinutes').append(this._spanIcon(this._options.icons.down))));
             }
             if (this._isEnabled('s')) {
                 if (this._isEnabled('m')) {
@@ -103,8 +107,8 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     href: '#',
                     tabindex: '-1',
                     'title': this._options.tooltips.incrementSecond
-                }).addClass('btn').attr('data-action', 'incrementSeconds').append($('<span>').addClass(this._options.icons.up))));
-                middleRow.append($('<td>').append($('<span>').addClass('timepicker-second').attr({
+                }).addClass('btn').attr('data-action', 'incrementSeconds').append(this._spanIcon(this._options.icons.up))));
+                middleRow.append($('<td>').append(this._spanIcon('timepicker-second').attr({
                     'data-time-component': 'seconds',
                     'title': this._options.tooltips.pickSecond
                 }).attr('data-action', 'showSeconds')));
@@ -112,7 +116,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     href: '#',
                     tabindex: '-1',
                     'title': this._options.tooltips.decrementSecond
-                }).addClass('btn').attr('data-action', 'decrementSeconds').append($('<span>').addClass(this._options.icons.down))));
+                }).addClass('btn').attr('data-action', 'decrementSeconds').append(this._spanIcon(this._options.icons.down))));
             }
 
             if (!this.use24Hours) {
@@ -155,7 +159,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     tabindex: '-1',
                     'data-action': 'today',
                     'title': this._options.tooltips.today
-                }).append($('<span>').addClass(this._options.icons.today))));
+                }).append(this._spanIcon(this._options.icons.today))));
             }
             if (!this._options.sideBySide && this._hasDate() && this._hasTime()) {
                 let title, icon;
@@ -171,7 +175,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     tabindex: '-1',
                     'data-action': 'togglePicker',
                     'title': title
-                }).append($('<span>').addClass(icon))));
+                }).append(this._spanIcon(icon))));
             }
             if (this._options.buttons.showClear) {
                 row.push($('<td>').append($('<a>').attr({
@@ -179,7 +183,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     tabindex: '-1',
                     'data-action': 'clear',
                     'title': this._options.tooltips.clear
-                }).append($('<span>').addClass(this._options.icons.clear))));
+                }).append(this._spanIcon(this._options.icons.clear))));
             }
             if (this._options.buttons.showClose) {
                 row.push($('<td>').append($('<a>').attr({
@@ -187,7 +191,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                     tabindex: '-1',
                     'data-action': 'close',
                     'title': this._options.tooltips.close
-                }).append($('<span>').addClass(this._options.icons.close))));
+                }).append(this._spanIcon(this._options.icons.close))));
             }
             return row.length === 0 ? '' : $('<table>').addClass('table-condensed').append($('<tbody>').append($('<tr>').append(row)));
         }


### PR DESCRIPTION
Font Awesome 5 JS replaces <span class="fas fa-icon"></span> with an <svg> tag, crashing the CSS applied to <span>.
This fix creates icons in this format: <span><i class="fas fa-icon"></i></span>. After the FA5 render, the code results like this: <span><svg>...</svg></span>, so everything works again.

To simplify and avoid code redundancy, I added a _spanIcon() helper, refactoring all the "$('<span>').addClass(" with "this._spanIcon("