### PR TITLE
Updated composer.json to fix error message when installing via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "robloach/component-installer": "*",
     "components/jquery": ">=3.0.0",
     "moment/moment": ">=2.10.5",
-    "tempusdominus/core": "5.0.0-alpha17"
+    "tempusdominus/core": "5.0.*"
   },
   "extra": {
     "component": {


### PR DESCRIPTION
With the old version tempusdominus could not be installed, because it required a alpha package, which can not be installed with the default  "min-stability" value. (Error message: tempusdominus/bootstrap-4 5.1.1 requires tempusdominus/core 5.0.0-alpha17 -> satisfiable by tempusdominus/core[5.0.0-alpha17] but these conflict with your requirements or minimum-stability.)

Now it uses the stable 5.0 versions. Bugfix releases are also included, so a 5.0.1 version fullfill the dependency as well.