### PR TITLE
Fix jQuery's version condition

### DIFF
--- a/build/js/tempusdominus-bootstrap-4.js
+++ b/build/js/tempusdominus-bootstrap-4.js
@@ -10,7 +10,7 @@ if (typeof jQuery === 'undefined') {
 
 +function ($) {
   var version = $.fn.jquery.split(' ')[0].split('.');
-  if ((version[0] < 2 && version[1] < 9) || (version[0] === 1 && version[1] === 9 && version[2] < 1) || (version[0] >= 4)) {
+  if ((version[0] < 2 && version[1] < 9) || (version[0] == 1 && version[1] == 9 && version[2] < 1) || (version[0] >= 4)) {
     throw new Error('Tempus Dominus Bootstrap4\'s requires at least jQuery v3.0.0 but less than v4.0.0');
   }
 }(jQuery);


### PR DESCRIPTION
Must use double == since you compare string and number (so, '1' === 1 will be false).
Also, I think the error message or the condition ins't correct because it accepts some version before 3.0.0 (I use it with jQuery 1.11.1 and it pass the condition).