### PR TITLE
Use dateViewBreakPoint and timeViewBreakPoint

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -215,7 +215,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                 if (this._options.toolbarPlacement === 'top') {
                     template.append(toolbar);
                 }
-                template.append($('<div>').addClass('row').append(dateView.addClass('col-md-6')).append(timeView.addClass('col-md-6')));
+                template.append($('<div>').addClass('row').append(dateView.addClass(this._options.dateViewBreakPoint)).append(timeView.addClass(this._options.timeViewBreakPoint)));
                 if (this._options.toolbarPlacement === 'bottom' || this._options.toolbarPlacement === 'default') {
                     template.append(toolbar);
                 }


### PR DESCRIPTION
Allows `sideBySide` to render correctly with Bootstrap 4 while also allowing customizable breakpoints.

This is an issue I'm currently experiencing. 

Requires tempusdominus/core/pull/16
Closes #87

**Before**
<img width="567" alt="Before" src="https://user-images.githubusercontent.com/7314701/62753095-0bc67080-ba38-11e9-8af6-aa82181dc231.png">

**After**
<img width="568" alt="After" src="https://user-images.githubusercontent.com/7314701/62753101-11bc5180-ba38-11e9-849b-d77b8e78d0a5.png">