### PR TITLE
fixed removing resize event listener

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -900,7 +900,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
             }
             this.widget.hide();
 
-            $(window).off('resize', this._place());
+            $(window).off('resize', this._place);
             this.widget.off('click', '[data-action]');
             this.widget.off('mousedown', false);
 


### PR DESCRIPTION
When the date picker closes, the window resize event listener is meant to be removed, but instead of referencing the handler function, it calls it.  This causes all window resize handlers on the page to be removed, as if calling $(window).off("resize");

This fixes that issue.