### PR TITLE
Add setMultiDate function

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -1086,6 +1086,14 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
             }
         }
 
+        setMultiDate(multiDateArray) {
+            var dateFormat = this._options.format;
+            for (let index = 0; index < multiDateArray.length; index++) {
+                let date = moment(multiDateArray[index], dateFormat);
+                this._setValue(date, index);
+            }
+        };
+
         //static
         static _jQueryHandleThis(me, option, argument) {
             let data = $(me).data(DateTimePicker.DATA_KEY);


### PR DESCRIPTION
Add setMultiDate function, make developer easy to set dates when allowMultidate is true.

```html
<div class="input-group date" id="datetimepicker1" data-target-input="nearest">
  <input type="text" class="form-control datetimepicker-input" data-target="#datetimepicker1"/>
  <div class="input-group-append" data-target="#datetimepicker1" data-toggle="datetimepicker">
    <div class="input-group-text"><i class="fa fa-calendar"></i></div>
  </div>
</div>
```

```javascript
$("#datetimepicker1").datetimepicker({
    allowMultidate: true,
    format: "YYYY/MM/DD",
    multidateSeparator: ",",
});

var multiDateArray = ["2019/11/01", "2019/11/02", "2019/11/03"];
$("#datetimepicker1").datetimepicker("setMultiDate", multiDateArray);
```