### PR TITLE
Fix bug on input cleared after min/max dat set

### DIFF
--- a/build/js/tempusdominus-bootstrap-4.js
+++ b/build/js/tempusdominus-bootstrap-4.js
@@ -776,7 +776,7 @@ var DateTimePicker = function ($, moment) {
         };
 
         DateTimePicker.prototype._getLastPickedDate = function _getLastPickedDate() {
-            return this._dates[this._getLastPickedDateIndex()];
+            return this._dates[this._getLastPickedDateIndex()] || this.getMoment();
         };
 
         DateTimePicker.prototype._getLastPickedDateIndex = function _getLastPickedDateIndex() {


### PR DESCRIPTION
In a datetimepicker with min or max date, after clear input the datetimepicker stop working. Reproduce the error in [https://jsfiddle.net/cacpgomes/web3h8ks/12/]
. Set a date in #datetimepicker7
. Set a date in #datetimepicker8
. Clear input for #datetimepicker8
. Try to pick a date in #datetimepicker8 - not working