### PR TITLE
Fix for issue #325 - https://github.com/tempusdominus/bootstrap-4/issues/325

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -359,7 +359,8 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
             }
 
             months.removeClass('active');
-            if (this._getLastPickedDate().isSame(this._viewDate, 'y') && !this.unset) {
+            const lastPickedDate = this._getLastPickedDate();
+            if (lastPickedDate && lastPickedDate.isSame(this._viewDate, 'y') && !this.unset) {
                 months.eq(this._getLastPickedDate().month()).addClass('active');
             }
 


### PR DESCRIPTION
## Demonstration of the issue
https://jsfiddle.net/fjcqm0hu/1/

```html
<div class="container">
  <div class="row">
    <div class="col-sm-6">
      <div class="form-group">
        <div class="input-group date" id="datetimepicker1" data-target-input="nearest">
          <input type="text" class="form-control datetimepicker-input" data-target="#datetimepicker1" />
          <div class="input-group-append" data-target="#datetimepicker1" data-toggle="datetimepicker">
            <div class="input-group-text"><i class="fa fa-calendar"></i></div>
          </div>
        </div>
      </div>
    </div>
  </div>
</div>

```

```js
$(function () {
  $('#datetimepicker1').datetimepicker({
    allowMultidate: true,
    multidateSeparator: ','
  });
});
```

The same issue happens on the documentation website (https://tempusdominus.github.io/bootstrap-4/Usage/#multidate).

If all the dates of a picker in multidate mode are removed by clicking on each selected date until there are no more selected, an error `Uncaught TypeError: Cannot read property 'isSame' of undefined` occurs.

## What the change does
Fixes the issue #325, which does not log the following error on the console anymore when all the dates of a picker in multidate mode are unset:

```
tempusdominus-bootstrap-4.js:1947 Uncaught TypeError: Cannot read property 'isSame' of undefined
    at TempusDominusBootstrap4._updateMonths (tempusdominus-bootstrap-4.js:1947)
    at TempusDominusBootstrap4._fillDate (tempusdominus-bootstrap-4.js:2116)
    at TempusDominusBootstrap4._update (tempusdominus-bootstrap-4.js:401)
    at TempusDominusBootstrap4._setValue (tempusdominus-bootstrap-4.js:430)
    at TempusDominusBootstrap4._doAction (tempusdominus-bootstrap-4.js:2294)
    at HTMLTableCellElement.e (jquery-3.2.1.slim.min.js:2)
    at HTMLDivElement.dispatch (jquery-3.2.1.slim.min.js:3)
    at HTMLDivElement.q.handle (jquery-3.2.1.slim.min.js:3)
```
