### PR TITLE
No safari issue with DST change at midnight

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -480,7 +480,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                 daysViewHeader.eq(2).addClass('disabled');
             }
 
-            currentDate = this._viewDate.clone().startOf('M').startOf('w').startOf('d');
+            currentDate = this._viewDate.clone().startOf('M').startOf('w').add(12, 'hours');
 
             for (i = 0; i < 42; i++) {
                 //always display 42 days (should show 6 weeks)


### PR DESCRIPTION
To reproduce the issue, you need to have safari (on current iOS/macOS)
on a localization with DST at midnight that goes from 00:00 to 23:00
when an hour is removed (Chile, Cuba, Iran, Jordan, Lebanon, Palestine,
Paraguay and Syria).

In these localization, depending on some heuristic the month view could
have duplicated days or not work at all for a given month.

eg. with Lebanon localization, showing "April 2020" month view will
throw an error "TypeError: undefined is not an object (evaluating
'row.append')" because with the current code:

```
this._viewDate.clone().startOf('M').startOf('w').startOf('d');
// .startOf('M') => Apr 01 00:00:00
// .startOf('w') => Mar 28 23:00:00 #(in other browsers Mar 29 00:00:00)
// .startOf('d') => Mar 28 00:00:00 #(in other browsers Mar 29 00:00:00)
```

=> we do not start with a first day of the week so doing:

https://github.com/tempusdominus/bootstrap-4/blob/bb8cd3cc4924d560f6e52155fa4229156f51337b/src/js/tempusdominus-bootstrap-4.js#L522

causes an error (because row is `undefined` since we are not on `currentDate.weekday() === 0`) that makes the month of April unusable.

> ![2020-10-20-180352_1508x609_scrot](https://user-images.githubusercontent.com/9977887/96613001-bc97f300-12fe-11eb-99f4-8881e2f5e024.png)

with the same setup, showing "March 2020", the month view works but there is two "28" days:

> ![2020-10-20-180430_388x454_scrot](https://user-images.githubusercontent.com/9977887/96613149-e5b88380-12fe-11eb-8207-e69446ff8ae4.png)

Other reports of the issue itself:

- https://www.donedone.com/timezone-specific-browser-specific-datetime-bug-2014/
- `https://github.com/date-fns/date-fns/issues/571`
- https://forum.mobiscroll.com/t/issue-with-invalid-dates-range-script/108

Reports of the issue in bootstrap-datetimepicker:

- https://github.com/Eonasdan/bootstrap-datetimepicker/issues/855
- https://github.com/Eonasdan/bootstrap-datetimepicker/issues/881
- https://github.com/Eonasdan/bootstrap-datetimepicker/issues/966