### PR TITLE
Escapes `[` and `]` characters in selector

### DIFF
--- a/src/js/tempusdominus-bootstrap-4.js
+++ b/src/js/tempusdominus-bootstrap-4.js
@@ -15,6 +15,7 @@ const TempusDominusBootstrap4 = ($ => { // eslint-disable-line no-unused-vars
                 selector = $element.attr('href') || '';
                 selector = /^#[a-z]/i.test(selector) ? selector : null;
             }
+            selector = selector.replace("[", "\\[").replace("]", "\\]");
             $selector = $(selector);
             if ($selector.length === 0) {
                 return $element;


### PR DESCRIPTION
Sorry I know there are a lot of changes going on right now, so I'm not sure if this PR is even to the right repo. Please let me know if I need to make it to https://github.com/tonix-tuft/tempusdominus-bootstrap instead. Happy New Year 🎉 

**Issue**
When the input field has an id with brackets in it, TD stops working because jQuery isn't able to find the element. 
Example https://jsfiddle.net/mpLngd81/

Please read this [blog post](https://eonasdan.com/state-of-my-picker)
